### PR TITLE
changed how temp is read, added min/max to perf_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ RPI TEMP CRITICAL: Temperature 106.34 is higher than critical threshold (105.00)
 ## NRPE example
 ```
 # Without command args
-command[check_rpi_temp]=sudo /usr/lib/nagios/plugins/check_rpi_temp.py
+command[check_rpi_temp]=/usr/lib/nagios/plugins/check_rpi_temp.py
 
 # With command args
-command[check_rpi_temp]=sudo /usr/lib/nagios/plugins/check_rpi_temp.py -w $ARG1$ -c $ARG2$
+command[check_rpi_temp]=/usr/lib/nagios/plugins/check_rpi_temp.py -w $ARG1$ -c $ARG2$
 ```

--- a/check_rpi_temp.py
+++ b/check_rpi_temp.py
@@ -26,9 +26,10 @@
 # History:
 # 20190930 0.1: Created plugin
 # 20190930 0.2: Catch output problems of vcgencmd command
+# 20200207 0.3: Changed how temperature is read, added min/max to perf_data
 ######################################################################
 # version
-version=0.2
+version=0.3
 
 # imports
 import os
@@ -40,6 +41,8 @@ unit='c'
 temp=0
 warn=0
 crit=0
+max_temp=85
+min_temp=0
 
 # Parameters
 usage = "Usage: %prog [-u (c|f)]\n"
@@ -61,19 +64,19 @@ if (args.crit):
 
 
 # Get temperature
-temp = os.popen("/usr/bin/vcgencmd measure_temp | egrep -o '[0-9]*\.[0-9]*'").read()
+temp = os.popen("cat /sys/class/thermal/thermal_zone0/temp").read()
 try:
-    temp = float(temp)
+    temp = float(temp)/1000
 except:
     #raise
-    print("RPI TEMP UNKNOWN: Unable to read output of '/usr/bin/vcgencmd measure_temp'. Try different user or use sudo?")
+    print("RPI TEMP UNKNOWN: Unable to read output of '/sys/class/thermal/thermal_zone0/temp'")
     sys.exit(3)
 
 if (unit == 'f'):
     temp = (temp*9/5)+32
 
 # Prep performance data
-perfdata = "|rpi_temp=%.2f;%.2f;%.2f;;" % (temp, warn, crit)
+perfdata = "|rpi_temp=%.2f;%.2f;%.2f;%.2f;%.2f" % (temp, warn, crit, min_temp, max_temp)
 
 # Check against thresholds
 if (crit > 0 and temp>=crit):


### PR DESCRIPTION
First of all, thank you for this very useful plugin :+1: 

I've experienced some difficulties with permissions. I've also tried to add the `nagios` user to to `video` group, however this didn't work when running the command remotely (I'm using Icing2). 
Therefore I changed the method how the temperature is read to a more "robust" way which doesn't relay on a "third" command and special group memberships / permissions.

I've also adjusted the perf_data a bit to get these fancy graphs:
![image](https://user-images.githubusercontent.com/1969330/74029843-851e2c00-49a5-11ea-8ed9-a95ba039be9b.png)
